### PR TITLE
ref: changed colors to support transparent/blur backgrounds

### DIFF
--- a/dist/catppuccin-frappe
+++ b/dist/catppuccin-frappe
@@ -1,5 +1,8 @@
 *.default=true
 *.normal=true
+*.selected.bold=true
+*.selected.bg=#c6d0f5
+*.selected.fg=#303446
 
 default.fg=#c6d0f5
 
@@ -17,18 +20,21 @@ border.fg=#232634
 border.bold=true
 
 msglist_unread.bold=true
+msglist_unread.fg=#a6d189
+msglist_unread.selected.bg=#a6d189
+msglist_unread.selected.fg=#303446
 msglist_flagged.fg=#e5c890
 msglist_flagged.bold=true
 msglist_result.fg=#8caaee
 msglist_result.bold=true
 msglist_*.selected.bold=true
-msglist_*.selected.bg=#414559
+msglist_*.selected.bg=#c6d0f5
 
 dirlist_*.selected.bold=true
-dirlist_*.selected.bg=#414559
+dirlist_*.selected.bg=#c6d0f5
 
-statusline_default.fg=#949cbb
-statusline_default.bg=#414559
+statusline_default.fg=#c6d0f5
+statusline_default.bg=#303446
 statusline_error.bold=true
 statusline_success.bold=true
 

--- a/dist/catppuccin-latte
+++ b/dist/catppuccin-latte
@@ -1,5 +1,8 @@
 *.default=true
 *.normal=true
+*.selected.bold=true
+*.selected.bg=#4c4f69
+*.selected.fg=#eff1f5
 
 default.fg=#4c4f69
 
@@ -17,18 +20,21 @@ border.fg=#dce0e8
 border.bold=true
 
 msglist_unread.bold=true
+msglist_unread.fg=#40a02b
+msglist_unread.selected.bg=#40a02b
+msglist_unread.selected.fg=#eff1f5
 msglist_flagged.fg=#df8e1d
 msglist_flagged.bold=true
 msglist_result.fg=#1e66f5
 msglist_result.bold=true
 msglist_*.selected.bold=true
-msglist_*.selected.bg=#ccd0da
+msglist_*.selected.bg=#4c4f69
 
 dirlist_*.selected.bold=true
-dirlist_*.selected.bg=#ccd0da
+dirlist_*.selected.bg=#4c4f69
 
-statusline_default.fg=#7c7f93
-statusline_default.bg=#ccd0da
+statusline_default.fg=#4c4f69
+statusline_default.bg=#eff1f5
 statusline_error.bold=true
 statusline_success.bold=true
 

--- a/dist/catppuccin-macchiato
+++ b/dist/catppuccin-macchiato
@@ -1,5 +1,8 @@
 *.default=true
 *.normal=true
+*.selected.bold=true
+*.selected.bg=#cad3f5
+*.selected.fg=#24273a
 
 default.fg=#cad3f5
 
@@ -17,18 +20,21 @@ border.fg=#181926
 border.bold=true
 
 msglist_unread.bold=true
+msglist_unread.fg=#a6da95
+msglist_unread.selected.bg=#a6da95
+msglist_unread.selected.fg=#24273a
 msglist_flagged.fg=#eed49f
 msglist_flagged.bold=true
 msglist_result.fg=#8aadf4
 msglist_result.bold=true
 msglist_*.selected.bold=true
-msglist_*.selected.bg=#363a4f
+msglist_*.selected.bg=#cad3f5
 
 dirlist_*.selected.bold=true
-dirlist_*.selected.bg=#363a4f
+dirlist_*.selected.bg=#cad3f5
 
-statusline_default.fg=#939ab7
-statusline_default.bg=#363a4f
+statusline_default.fg=#cad3f5
+statusline_default.bg=#24273a
 statusline_error.bold=true
 statusline_success.bold=true
 

--- a/dist/catppuccin-mocha
+++ b/dist/catppuccin-mocha
@@ -1,5 +1,8 @@
 *.default=true
 *.normal=true
+*.selected.bold=true
+*.selected.bg=#cdd6f4
+*.selected.fg=#1e1e2e
 
 default.fg=#cdd6f4
 
@@ -17,18 +20,21 @@ border.fg=#11111b
 border.bold=true
 
 msglist_unread.bold=true
+msglist_unread.fg=#a6e3a1
+msglist_unread.selected.bg=#a6e3a1
+msglist_unread.selected.fg=#1e1e2e
 msglist_flagged.fg=#f9e2af
 msglist_flagged.bold=true
 msglist_result.fg=#89b4fa
 msglist_result.bold=true
 msglist_*.selected.bold=true
-msglist_*.selected.bg=#313244
+msglist_*.selected.bg=#cdd6f4
 
 dirlist_*.selected.bold=true
-dirlist_*.selected.bg=#313244
+dirlist_*.selected.bg=#cdd6f4
 
-statusline_default.fg=#9399b2
-statusline_default.bg=#313244
+statusline_default.fg=#cdd6f4
+statusline_default.bg=#1e1e2e
 statusline_error.bold=true
 statusline_success.bold=true
 


### PR DESCRIPTION
Hi!,

I gave this port a try and noticed that it is kinda hard to know what file/message/dir is selected if the background is not the one expected by the color palette. To fix this, I decided to reverse the colors on selected items and add bold on the text.

I would appreciate any comment to improve this changes.

Thanks in advance.